### PR TITLE
Python: Enable use on Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,9 +48,6 @@ jobs:
     - name: Set up project
       run: |
 
-        # Adjust baseline dependencies.
-        pip install --prefer-binary --upgrade --requirement=requirements-dev.txt
-
         # Install package in editable mode.
         pip install --prefer-binary --editable=.[develop]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.6", "3.11"]
+        python-version: ["3.6", "3.12"]
 
     env:
       OS: ${{ matrix.os }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,0 @@
-pip<23
-setuptools<70

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ multi_line_output = 3
 not_skip = __init__.py
 
 [tool:pytest]
-addopts = --flake8 --mypy --mypy-ignore-missing-imports --isort --crate-version latest-testing --doctest-glob="tests/*.rst"
+addopts = -vvv --flake8 --isort --mypy --crate-version latest-testing --doctest-glob="tests/*.rst"
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS
 flake8-max-line-length = 88
 flake8-ignore = E203 W503

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,22 @@
 import os
 from pathlib import Path
 
-from pkg_resources.extern.packaging.version import Version
 from setuptools import setup
 
-# a version must be PEP 440 compliant
-__version__ = Version("0.4.dev0")
 
-
-def cwd() -> Path:
+def here() -> Path:
     return Path(os.path.dirname(__file__))
 
 
 def read(path: str) -> str:
-    filepath: Path = cwd() / path
+    filepath: Path = here() / path
     with open(filepath.absolute(), "r", encoding="utf-8") as f:
         return f.read()
 
 
 setup(
     name="pytest-cratedb",
-    version=str(__version__),
+    version="0.4.0.dev0",
     description="Manages CrateDB instances during your integration tests",
     long_description=read("README.rst"),
     author="Christian Haudum",
@@ -59,6 +55,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Testing",
         "Topic :: Database",
     ],

--- a/tests/layer.rst
+++ b/tests/layer.rst
@@ -3,7 +3,7 @@ Pytest Crate
 ============
 
 Pytest fixtures can also be used in doctests, however, doctests always capture
-the outout of any method calls.
+the output of any method calls.
 
 Therefore the pytest fixture must not print anything to stdout/stderr but
 rather use a logger.

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -4,7 +4,7 @@ from crate.client import connect
 
 @pytest.fixture(scope="session")
 def custom_crate_a(crate_layer):
-    yield from crate_layer("crate_a", "5.4.x")
+    yield from crate_layer("crate_a", "5.8.x")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## About
Remove deprecated code in `setup.py` to make package installation work on Python 3.12.

## Details
A few other maintenance commits.
